### PR TITLE
Navigation: Multiple instances, generalize terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,19 @@ supports rewriting ES2015 or later syntax.
 
 ## Overview
 
-The library provides two objects: `navigation` and `spinner`.
+The library provides two objects: `navigation` and `spinner`. These objects 
+must be instantiated with `new` and can be provided an object of configuration 
+options. All modules have the option `container` which defines a query selector 
+for an element to insert the fragment into.
 
 ### Navigation
 
-Create a navigation bar to switch between view for different projects. The URL 
-state is changed via the location hash, which is also checked on startup.
+Create a navigation bar to switch between view for different selections. The 
+URL state is changed via the location hash, which is also checked on startup.
+Multiple navigation objects can exist concurrently if a unique `prefix` is 
+given to each of them. By default, the first item in the navigation is 
+selected, but this can be overridden by returning `true` in `setCurrentItem`, 
+in which case nothing is selected if an unknown location hash is set at start.
 
 Setup:
 
@@ -30,16 +37,25 @@ Setup:
 const projectsList = ['BAR', 'BAZ', 'FOO'];
 const projectsNavigation = new navigation({
     container: '#navigation',
-    setCurrentProject: (project, hasProject) => {
+    prefix: 'project_',
+    setCurrentItem: (project, hasProject) => {
         if (!hasProject) {
-            console.log('A non-project was selected: ' + project);
+            console.log('An unknown project was selected: ' + project);
         }
-        console.log('Selected project: ' + project);
+        else {
+            console.log('Selected project: ' + project);
+        }
+        return hasProject;
+    },
+    addElement: (element) => {
+        element.text(d => `Project ${d}`);
     }
 })
 projectsNavigation.start(projectsList);
 
-location.hash = '#FOO';
+location.hash = '#project_FOO'; // Select the third project
+location.hash = '#FOO'; // Not handled
+location.hash = '#project_QUX'; // Unknown project selected
 ```
 
 ### Spinner

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -1,5 +1,5 @@
 /*
-Project navigation UI fragment.
+Item navigation UI fragment.
 
 Copyright 2017 ICTU
 
@@ -22,50 +22,63 @@ const defaultConfiguration = {
     window: window,
     location: location,
     container: "#navigation",
-    setCurrentProject: (project, hasProject) => {}
+    prefix: "",
+    setCurrentItem: (item, hasItem) => { return hasItem; },
+    addElement: (element) => {
+        element.text(d => d);
+    }
 };
 
 class navigation {
-    // Create a new project navigation with the given configuration
+    // Create a new navigation with the given configuration
     constructor(configuration = {}) {
         this.config = Object.assign({}, defaultConfiguration, configuration);
-        this.currentProject = null;
+        this.currentItem = null;
+    }
+
+    checkHash(hash) {
+        if (hash.startsWith(`#${this.config.prefix}`)) {
+            return this.setCurrentItem(hash.substring(this.config.prefix.length + 1));
+        }
+        return false;
     }
 
     // Create the navigation list
-    start(projects) {
+    start(items) {
         d3.select(this.config.container).append('ul');
-        this.update(projects);
+        this.update(items);
 
-        const hash = this.config.location.hash.substring(1);
-        this.setCurrentProject(hash === "" ? projects[0] : hash);
+        if (!this.checkHash(this.config.location.hash) && items.length !== 0) {
+            this.setCurrentItem(items[0]);
+        }
+
         // Use event listeners rather than d3 for jsdom compatibility
         this.config.window.addEventListener("hashchange", () => {
-            this.setCurrentProject(this.config.location.hash.substring(1));
+            this.checkHash(this.config.location.hash);
         });
     }
 
-    update(projects) {
+    update(items) {
         d3.select(this.config.container + ' ul').selectAll('li')
-            .data(projects)
+            .data(items)
             .enter()
             .append('li')
-            .classed('is-active', d => d === this.currentProject)
+            .classed('is-active', d => d === this.currentItem)
             .append('a')
-            .text(d => d)
-            .attr('href', (project) => `#${project}`);
+            .attr('href', (item) => `#${this.config.prefix}${item}`)
+            .call(this.config.addElement);
     }
 
-    setCurrentProject(project) {
-        this.currentProject = project;
+    setCurrentItem(item) {
+        this.currentItem = item;
 
         const container = d3.select(this.config.container);
         container.selectAll('ul li')
-            .classed('is-active', d => d === project);
+            .classed('is-active', d => d === item);
 
-        const hasProject = !container.select('ul li.is-active').empty();
+        const hasItem = !container.select('ul li.is-active').empty();
 
-        this.config.setCurrentProject(project, hasProject);
+        return this.config.setCurrentItem(item, hasItem);
     }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -93,6 +93,71 @@ describe('Navigation', () => {
             done();
         });
     });
+
+    it('Works with multiple navigations', (done) => {
+        const { window, d3, navigation } = setup('<div id="projects"></div><div id="times"></div>', done);
+        const projectsNavigation = new navigation({
+            container: '#projects',
+            prefix: 'project_'
+        });
+        projectsNavigation.start(projectsList);
+
+        const timeNavigation = new navigation({
+            container: '#times',
+            prefix: 'time_'
+        });
+        timeNavigation.start(['month', 'week', 'day', 'hour']);
+
+        const projects = d3.selectAll('#projects ul li'),
+              times = d3.selectAll('#times ul li');
+        var activeProject = 1;
+        var activeTime = 1;
+        var next = () => {};
+        function updateNavigation(hash, project, time, chain) {
+            activeProject = project;
+            activeTime = time;
+            next = chain;
+            window.location.hash = hash;
+        }
+        function checkNavigation() {
+            const hash = window.location.hash;
+            assert.isTrue(projects.filter(`:nth-child(${activeProject})`).classed('is-active'), `Project selected for ${hash}: ${activeProject}`);
+            assert.isTrue(times.filter(`:nth-child(${activeTime})`).classed('is-active'), `Time selected for ${hash}: ${activeTime}`);
+            next();
+        }
+
+        window.addEventListener("hashchange", checkNavigation);
+        checkNavigation();
+        updateNavigation("#project_FOO", 3, 1, () => {
+            updateNavigation("#time_week", 3, 2, () => {
+                updateNavigation("#day", 3, 2, () => {
+                    done();
+                });
+            });
+        });
+    });
+
+    it('Honors callback actions', (done) => {
+        const { window, d3, navigation } = setup('<div id="navigation"></div>', done);
+        window.location.hash = "#something_else";
+        const projectsNavigation = new navigation({
+            setCurrentItem: (item, hasItem) => {
+                // Pretend we do something with the item, and since it does
+                // not exist in the navigation we do not select any item, even
+                // the first.
+                return true;
+            },
+            addElement: (element) => {
+                element.text(d => `Project ${d}`);
+            }
+        });
+        projectsNavigation.start(projectsList);
+        const items = d3.selectAll('#navigation ul li'),
+              first = items.filter(":nth-child(1)");
+        assert.isFalse(first.classed('is-active'), 'First element not selected');
+        assert.equal(first.select('a').text(), 'Project BAR');
+        done();
+    });
 });
 
 describe('Spinner', () => {


### PR DESCRIPTION
- Configuration option to set a prefix for the navigation; other hashes
  are always ignored.
- Replace 'project' with 'item' for generalization
- Let the callback for current item change provide a return value to
  decide if the first item should be selected when the initial hash
  is not in the list, and only do so if the list has items.
- Callback for setting item link properties such as text and attributes.
- Update documentation and unit tests