### PR TITLE
Test report, coverage, Coveralls and Sonar scan

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "test": {
+      "plugins": [ "istanbul" ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ Thumbs.db
 *.tmp
 *.swp
 *.bak
-node_modules
+test-report.xml
+.nyc_output/
+coverage/
+node_modules/
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@ node_js:
   - "6"
   - "7"
   - "8"
+after_script:
+  - sonar-scanner -Dsonar.login=$SONAR_TOKEN
+after_success:
+  - npm run coveralls
+addons:
+    sonarcloud:
+        organization: ictu-gros

--- a/package.json
+++ b/package.json
@@ -22,10 +22,15 @@
     "url": "https://github.com/ICTU/gros-visualization-ui/issues"
   },
   "scripts": {
-    "pretest": "cross-env NODE_ENV=production webpack --hide-modules",
-    "test": "cross-env NODE_ENV=development mocha tests",
+    "pretest": "cross-env NODE_ENV=test webpack --hide-modules",
+    "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text mocha --reporter=spec --reporter mocha-sonar-generic-test-coverage --reporter-options outputFile=test-report.xml tests",
+    "coveralls": "cross-env NODE_ENV=test nyc report --reporter=text-lcov | cross-env NODE_ENV=test coveralls",
     "preversion": "npm test",
     "postversion": "git push && git push --tags"
+  },
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false
   },
   "dependencies": {
     "d3": "^4.12.0",
@@ -33,10 +38,17 @@
     "sprintf-js": "^1.1.1"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-plugin-istanbul": "^4.1.5",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
     "cross-env": "^5.1.1",
     "jsdom": "^11.5.1",
     "mocha": "^4.0.1",
+    "mocha-sonar-generic-test-coverage": "0.0.6",
+    "nyc": "^11.6.0",
     "webpack": "^3.10.0"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=ictu-gros:visualization-ui
+# this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
+sonar.projectName=Visualization UI
+sonar.projectVersion=0.4.0
+ 
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# This property is optional if sonar.modules is set. 
+sonar.sources=lib
+sonar.tests=tests
+sonar.testExecutionReportPaths=test-report.xml
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+ 
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,5 +23,19 @@ module.exports = {
         path: __dirname + "/dist",
         filename: "bundle.js"
     },
-    devtool: 'cheap-source-map'
+    devtool: 'cheap-source-map',
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['babel-preset-env']
+                    }
+                }
+            }
+        ]
+    }
 };


### PR DESCRIPTION
- Generate a generic XML test report for Sonar.
- Use Babel loader and Istanbul instrumentation in order to generate
  coverage for the webpack-compiled modules used in JSDOM.
- Upload results to coveralls and Sonar.