### PR TITLE
Navigation: Support updating and removing items

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ checked on startup.
 Multiple navigation objects can exist concurrently if a unique `prefix` is 
 given to each of them. By default, the first item in the navigation is 
 selected, but this can be overridden by returning `true` in `setCurrentItem`, 
-in which case nothing is selected if an unknown location hash is set at start.
+in which case nothing is selected if an unknown item is set in the location 
+hash at start.
 
-Setup:
+Setup and usage:
 
 ```js
 const projectsList = ['BAR', 'BAZ', 'FOO'];
@@ -132,12 +133,16 @@ const projectsNavigation = new navigation({
     addElement: (element) => {
         element.text(d => `Project ${d}`);
     }
+    // updateElement and removeElement can also access element selections
 })
 projectsNavigation.start(projectsList);
 
 location.hash = '#project_FOO'; // Select the third project
 location.hash = '#FOO'; // Not handled
 location.hash = '#project_QUX'; // Unknown project selected
+
+// Update navigation list
+projectsNavigation.update(projectsList.concat('QUX', 'ZUR'));
 ```
 
 ### Spinner

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -24,9 +24,12 @@ const defaultConfiguration = {
     container: "#navigation",
     prefix: "",
     setCurrentItem: (item, hasItem) => { return hasItem; },
+    isActive: (d, currentItem) => d === currentItem,
     addElement: (element) => {
         element.text(d => d);
-    }
+    },
+    updateElement: (element) => {},
+    removeElement: (element) => { element.remove(); }
 };
 
 class navigation {
@@ -59,11 +62,16 @@ class navigation {
     }
 
     update(items) {
-        d3.select(this.config.container + ' ul').selectAll('li')
+        const list = d3.select(this.config.container + ' ul')
+            .selectAll('li')
             .data(items)
-            .enter()
+            .call(this.config.updateElement);
+        list.exit().call(this.config.removeElement);
+        list.enter()
             .append('li')
-            .classed('is-active', d => d === this.currentItem)
+            .classed('is-active',
+                d => this.config.isActive(d, this.currentItem)
+            )
             .append('a')
             .attr('href', (item) => `#${this.config.prefix}${item}`)
             .call(this.config.addElement);
@@ -73,12 +81,16 @@ class navigation {
         this.currentItem = item;
 
         const container = d3.select(this.config.container);
-        container.selectAll('ul li')
-            .classed('is-active', d => d === item);
+        const list = container.selectAll('ul li')
+            .classed('is-active', d => this.config.isActive(d, item));
 
-        const hasItem = !container.select('ul li.is-active').empty();
-
-        return this.config.setCurrentItem(item, hasItem);
+        const hasItem = this.config.setCurrentItem(item,
+            !container.select('ul li.is-active').empty()
+        );
+        if (hasItem) {
+            list.selectAll('a').call(this.config.updateElement);
+        }
+        return hasItem;
     }
 }
 


### PR DESCRIPTION
Add more callbacks to provide items with updates based on new items or
selection states, as well as to remove existing items. By default this
now allows updates of the navigation list.

Improve test branch coverage and update README.